### PR TITLE
Add package name invariance

### DIFF
--- a/eq-go/comparators.go
+++ b/eq-go/comparators.go
@@ -16,6 +16,10 @@ import (
 // Each method returns an int representing the result of the comparison check and a tree node
 // providing more info about the differences if the two inputs were not equivalent.
 
+// TODO: (kevinb) Refactor to avoid using global variables for these.
+var equivalentPackageNameA string
+var equivalentPackageNameB string
+
 type node struct {
 	msg      string
 	leftPos  token.Pos
@@ -133,6 +137,11 @@ func compareBools(a bool, b bool) (int, *node) {
 }
 
 func compareStrings(a string, b string) (int, *node) {
+	if equivalentPackageNameA != "" && equivalentPackageNameB != "" {
+		a = strings.ReplaceAll(a, equivalentPackageNameB, equivalentPackageNameA)
+		b = strings.ReplaceAll(b, equivalentPackageNameB, equivalentPackageNameA)
+	}
+
 	if a < b {
 		return -1, newNode(fmt.Sprintf("strings did not match: %s < %s", a, b), nil, nil, nil)
 	} else if a > b {

--- a/eq-go/eq-go.go
+++ b/eq-go/eq-go.go
@@ -25,6 +25,9 @@ func PackagesEquivalent(a *ast.Package, fsetA *token.FileSet, b *ast.Package, fs
 		panic(fmt.Errorf("missing package"))
 	}
 
+	equivalentPackageNameA = a.Name
+	equivalentPackageNameB = b.Name
+
 	mergeMode := ast.FilterUnassociatedComments | ast.FilterImportDuplicates
 	mergedFileA := ast.MergePackageFiles(a, mergeMode)
 	mergedFileB := ast.MergePackageFiles(b, mergeMode)


### PR DESCRIPTION
Ensure that if the two input packages have different names, this
does not affect their equivalence.